### PR TITLE
Use Swift's own wrapping arithmetics

### DIFF
--- a/Sources/MD5.swift
+++ b/Sources/MD5.swift
@@ -99,13 +99,10 @@ func rstr_md5(_ input: [CUnsignedChar]) -> [CUnsignedChar] {
 }
 
 /*
- * Add integers, wrapping at 2^32. This uses 16-bit operations internally
- * to work around bugs in some JS interpreters.
+ * Add integers, wrapping at 2^32.
  */
 func safe_add(_ x: Int32, _ y: Int32) -> Int32 {
-  let lsw = (x & 0xFFFF) + (y & 0xFFFF)
-  let msw = (x >> 16) + (y >> 16) + (lsw >> 16)
-  return (msw << 16) | (lsw & 0xFFFF)
+  return x &+ y
 }
 
 /*


### PR DESCRIPTION
Swift compiler takes 2-3 seconds to type check this function.

By using Swift's own wrapping arithmetics operators, we can make this code more readable and faster to compile.